### PR TITLE
staffとrightの重なり修正

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -851,7 +851,7 @@ footer {
 
 		.staff {
 			width: 70%;
-			margin: 0 auto;
+			margin: 200px auto;
 			display: flex;
 			flex-wrap: 
 		}


### PR DESCRIPTION
@aiss220 
`staff`のmarginの値を修正すると重ならずに済みます。
`left-img`と重なる`right`と重ならない`right`を用意して、PCとスマホで表示/非表示を切り替えてはいかがでしょうか？